### PR TITLE
Apply runic formatting

### DIFF
--- a/src/RegisterWorkerApertures.jl
+++ b/src/RegisterWorkerApertures.jl
@@ -10,20 +10,20 @@ import RegisterWorkerShell: worker, init!, close!, load_mm_package, workertid
 
 export Apertures, monitor, monitor!, worker
 
-mutable struct Apertures{A<:AbstractArray,K,N} <: AbstractWorker
+mutable struct Apertures{A <: AbstractArray, K, N} <: AbstractWorker
     fixed::A
-    nodes::NTuple{N,K}
-    maxshift::NTuple{N,Int}
-    affinepenalty::AffinePenalty{Float64,N}
-    overlap::NTuple{N,Int}
-    λrange::Union{Float64,Tuple{Float64,Float64}}
+    nodes::NTuple{N, K}
+    maxshift::NTuple{N, Int}
+    affinepenalty::AffinePenalty{Float64, N}
+    overlap::NTuple{N, Int}
+    λrange::Union{Float64, Tuple{Float64, Float64}}
     thresh::Float64  # Ipopt requires Float64
     preprocess  # likely of type PreprocessSNF, but could be a function
     normalization::Symbol
     correctbias::Bool
     tid::Int
     dev::Int
-    cuda_objects::Dict{Symbol,Any}
+    cuda_objects::Dict{Symbol, Any}
 end
 
 function load_mm_package(dev)
@@ -32,14 +32,14 @@ function load_mm_package(dev)
     else
         eval(:(using RegisterMismatch))
     end
-    nothing
+    return nothing
 end
 
 function init!(algorithm::Apertures)
     if algorithm.dev >= 0
         cuda_init!(algorithm)
     end
-    nothing
+    return nothing
 end
 
 function cuda_init!(algorithm)
@@ -56,12 +56,12 @@ function cuda_init!(algorithm)
     end
     fixed = algorithm.fixed
     T = cuda_eltype(eltype(fixed))
-    d_fixed  = CuArray{T}(sdata(fixed))
+    d_fixed = CuArray{T}(sdata(fixed))
     algorithm.cuda_objects[:d_fixed] = d_fixed
     algorithm.cuda_objects[:d_moving] = similar(d_fixed)
     gridsize = map(length, algorithm.nodes)
     aperture_width = default_aperture_width(algorithm.fixed, gridsize)
-    algorithm.cuda_objects[:cms] = CMStorage{T}(undef, aperture_width, algorithm.maxshift)
+    return algorithm.cuda_objects[:cms] = CMStorage{T}(undef, aperture_width, algorithm.maxshift)
 end
 
 function close!(algorithm::Apertures)
@@ -70,7 +70,7 @@ function close!(algorithm::Apertures)
             activate(old_active_context)
         end
     end
-    nothing
+    return nothing
 end
 
 """
@@ -134,17 +134,17 @@ pre-processing function, but see also `PreprocessSNF`.
 ```
 
 """
-function Apertures(fixed, nodes::NTuple{N,K}, maxshift, λrange, preprocess=identity; overlap=zeros(Int, N), normalization=:pixels, thresh_fac=(0.5)^ndims(fixed), thresh=nothing, correctbias::Bool=true, tid=1, dev=-1) where {K,N}
+function Apertures(fixed, nodes::NTuple{N, K}, maxshift, λrange, preprocess = identity; overlap = zeros(Int, N), normalization = :pixels, thresh_fac = (0.5)^ndims(fixed), thresh = nothing, correctbias::Bool = true, tid = 1, dev = -1) where {K, N}
     gridsize = map(length, nodes)
     overlap_t = (overlap...,) #Make tuple
     length(overlap) == N || throw(DimensionMismatch("overlap must have $N entries"))
     nimages(fixed) == 1 || error("Register to a single image")
-    isa(λrange, Number) || isa(λrange, Tuple{Number,Number}) || error("λrange must be a number or 2-tuple")
+    isa(λrange, Number) || isa(λrange, Tuple{Number, Number}) || error("λrange must be a number or 2-tuple")
     if thresh == nothing
-        thresh = (thresh_fac/prod(gridsize)) * (normalization==:pixels ? length(fixed) : sumabs2(fixed))
+        thresh = (thresh_fac / prod(gridsize)) * (normalization == :pixels ? length(fixed) : sumabs2(fixed))
     end
     λrange = isa(λrange, Number) ? Float64(λrange) : (Float64(first(λrange)), Float64(last(λrange)))
-    Apertures{typeof(fixed),K,N}(fixed, nodes, maxshift, AffinePenalty{Float64,N}(nodes, first(λrange)), overlap_t, λrange, Float64(thresh), preprocess, normalization, correctbias, tid, dev, Dict{Symbol,Any}())
+    return Apertures{typeof(fixed), K, N}(fixed, nodes, maxshift, AffinePenalty{Float64, N}(nodes, first(λrange)), overlap_t, λrange, Float64(thresh), preprocess, normalization, correctbias, tid, dev, Dict{Symbol, Any}())
 end
 
 function worker(algorithm::Apertures, img, tindex, mon)
@@ -154,20 +154,20 @@ function worker(algorithm::Apertures, img, tindex, mon)
     use_cuda = algorithm.dev >= 0
     if use_cuda
         device!(CuDevice(algorithm.dev))
-        d_fixed  = algorithm.cuda_objects[:d_fixed]
+        d_fixed = algorithm.cuda_objects[:d_fixed]
         d_moving = algorithm.cuda_objects[:d_moving]
-        cms      = algorithm.cuda_objects[:cms]
+        cms = algorithm.cuda_objects[:cms]
         copyto!(d_moving, moving)
         cs = coords_spatial(img)
-        aperture_centers = aperture_grid(map(d->size(img,d),cs), gridsize)
+        aperture_centers = aperture_grid(map(d -> size(img, d), cs), gridsize)
         mms = allocate_mmarrays(eltype(cms), gridsize, algorithm.maxshift)
-        mismatch_apertures!(mms, d_fixed, d_moving, aperture_centers, cms; normalization=algorithm.normalization)
+        mismatch_apertures!(mms, d_fixed, d_moving, aperture_centers, cms; normalization = algorithm.normalization)
     else
         #mms = mismatch_apertures(algorithm.fixed, moving, gridsize, algorithm.maxshift; normalization=algorithm.normalization)
         cs = coords_spatial(img) #
-        aperture_centers = aperture_grid(map(d->size(img,d),cs), gridsize)
+        aperture_centers = aperture_grid(map(d -> size(img, d), cs), gridsize)
         aperture_width = default_aperture_width(algorithm.fixed, gridsize, algorithm.overlap)  #
-        mms = mismatch_apertures(algorithm.fixed, moving, aperture_centers, aperture_width, algorithm.maxshift; normalization=algorithm.normalization)  #
+        mms = mismatch_apertures(algorithm.fixed, moving, aperture_centers, aperture_width, algorithm.maxshift; normalization = algorithm.normalization)  #
     end
     # displaymismatch(mms, thresh=10)
     if algorithm.correctbias
@@ -177,8 +177,8 @@ function worker(algorithm::Apertures, img, tindex, mon)
     cs = Array{Any}(undef, size(mms))
     Qs = Array{Any}(undef, size(mms))
     thresh = algorithm.thresh
-    for i = 1:length(mms)
-        E0[i], cs[i], Qs[i] = qfit(mms[i], thresh; opt=false)
+    for i in 1:length(mms)
+        E0[i], cs[i], Qs[i] = qfit(mms[i], thresh; opt = false)
     end
     mmis = interpolate_mm!(mms)
     λrange = algorithm.λrange
@@ -201,10 +201,10 @@ function worker(algorithm::Apertures, img, tindex, mon)
         warped = warp(moving0, ϕ)
         monitor!(mon, :warped0, warped)
     end
-    mon
+    return mon
 end
 
-cuda_eltype(::Type{T}) where {T<:Union{Float32,Float64}} = T
+cuda_eltype(::Type{T}) where {T <: Union{Float32, Float64}} = T
 cuda_eltype(::Any) = Float32
 
 workertid(alg::Apertures) = alg.tid

--- a/test/apertured.jl
+++ b/test/apertured.jl
@@ -1,107 +1,121 @@
-### Apertured registration
-# Create the data
-fixed = testimage("cameraman")
-gridsize = (5,5)
-shift_amplitude = 5
-u_dfm = shift_amplitude*randn(2, gridsize..., 4)
-aperturedtids = threadids()
-img = AxisArray(Array{Float64}(undef, size(fixed)..., 4), :y, :x, :time)
-tax = timeaxis(img)
-nodes = map(d->range(1, stop=size(fixed,d), length=gridsize[d]), (1,2))
-for i = 1:4
-    ϕ_dfm = GridDeformation(u_dfm[:,:,:,i], nodes)
-    img[tax(i)] = warp(fixed, ϕ_dfm)
-end
-# Perform the registration
-fn = joinpath(tempdir(), "apertured.jld")
-maxshift = (3*shift_amplitude, 3*shift_amplitude)
-algorithms = Apertures[Apertures(fixed, nodes, maxshift, 0.001; tid=t) for t in aperturedtids]
-prepare_mm_package(algorithms)
-mons = monitor(algorithms,
-               (),
-               Dict(:u => Array{SVector{2,Float64}}(undef, gridsize),
-                    :warped => Array{Float64}(undef, size(fixed)),
-                    :mismatch => 0.0))
-driver(fn, algorithms, img, mons)
-
-# With preprocessing
-fn_pp = joinpath(tempdir(), "apertured_pp.jld")
-pp = PreprocessSNF(0.1, [2,2], [10,10])
-algorithms = Apertures[Apertures(pp(fixed), nodes, maxshift, 0.001, pp; tid=t) for t in aperturedtids]
-prepare_mm_package(algorithms)
-mons = monitor(algorithms,
-               (),
-               Dict(:u => Array{SVector{2,Float64}}(undef, gridsize),
-                    :warped => Array{Float64}(undef, size(fixed)),
-                    :warped0 => Array{Float64}(undef, size(fixed)),
-                    :mismatch => 0.0))
-driver(fn_pp, algorithms, img, mons)
-
-# Again, this time with a constant shift (an easy case)
-imgt = copy(img)
-u_dfmt = copy(u_dfm)
-for i = 1:4
-    fill!(view(u_dfmt, 1, :, :, i), i)
-    fill!(view(u_dfmt, 2, :, :, i), 5-i)
-    ϕ_dfm = GridDeformation(u_dfmt[:,:,:,i], nodes)
-    imgt[tax(i)] = warp(fixed, ϕ_dfm)
-end
-
-fnt = joinpath(tempdir(), "apertured_translate.jld")
-maxshift = (3*shift_amplitude, 3*shift_amplitude)
-algorithms = Apertures[Apertures(fixed, nodes, maxshift, 0.001; tid=t) for t in aperturedtids]
-prepare_mm_package(algorithms)
-mons = monitor(algorithms,
-               (),
-               Dict(:u => Array{SVector{2,Float64}}(undef, gridsize),
-                    :warped => Array{Float64}(undef, size(fixed)),
-                    :mismatch => 0.0))
-driver(fnt, algorithms, imgt, mons)
-
-#using JLD, RegisterCore, RegisterMismatch
-
-jldopen(fnt) do f
-    mm = read(f["mismatch"])
-    u = read(f["u"])
-    @test maximum(abs, u+u_dfmt) < 0.5
-    warped = read(f["warped"])
-    for i = 1:nimages(img)
-        r0 = ratio(mismatch0(fixed, imgt[tax(i)]),0)
-        r1 = ratio(mismatch0(fixed, warped[:,:,i]), 0)
-        @test r0 > r1
+@testset "Apertured registration" begin
+    ### Apertured registration
+    # Create the data
+    fixed = testimage("cameraman")
+    gridsize = (5, 5)
+    shift_amplitude = 5
+    u_dfm = shift_amplitude * randn(2, gridsize..., 4)
+    aperturedtids = threadids()
+    img = AxisArray(Array{Float64}(undef, size(fixed)..., 4), :y, :x, :time)
+    tax = timeaxis(img)
+    nodes = map(d -> range(1, stop = size(fixed, d), length = gridsize[d]), (1, 2))
+    for i in 1:4
+        ϕ_dfm = GridDeformation(u_dfm[:, :, :, i], nodes)
+        img[tax(i)] = warp(fixed, ϕ_dfm)
     end
-end
+    # Perform the registration
+    fn = joinpath(tempdir(), "apertured.jld")
+    maxshift = (3 * shift_amplitude, 3 * shift_amplitude)
+    algorithms = Apertures[Apertures(fixed, nodes, maxshift, 0.001; tid = t) for t in aperturedtids]
+    prepare_mm_package(algorithms)
+    mons = monitor(
+        algorithms,
+        (),
+        Dict(
+            :u => Array{SVector{2, Float64}}(undef, gridsize),
+            :warped => Array{Float64}(undef, size(fixed)),
+            :mismatch => 0.0
+        )
+    )
+    driver(fn, algorithms, img, mons)
 
-nfailures = 0
+    # With preprocessing
+    fn_pp = joinpath(tempdir(), "apertured_pp.jld")
+    pp = PreprocessSNF(0.1, [2, 2], [10, 10])
+    algorithms = Apertures[Apertures(pp(fixed), nodes, maxshift, 0.001, pp; tid = t) for t in aperturedtids]
+    prepare_mm_package(algorithms)
+    mons = monitor(
+        algorithms,
+        (),
+        Dict(
+            :u => Array{SVector{2, Float64}}(undef, gridsize),
+            :warped => Array{Float64}(undef, size(fixed)),
+            :warped0 => Array{Float64}(undef, size(fixed)),
+            :mismatch => 0.0
+        )
+    )
+    driver(fn_pp, algorithms, img, mons)
 
-jldopen(fn) do f
-    global nfailures
-    mm = read(f["mismatch"])
-    @test all(mm .> 0)
-    warped = read(f["warped"])
-    for i = 1:nimages(img)
-        r0 = ratio(mismatch0(fixed, img[tax(i)]),0)
-        r1 = ratio(mismatch0(fixed, warped[:,:,i]), 0)
-        nfailures += r0 <= r1
+    # Again, this time with a constant shift (an easy case)
+    imgt = copy(img)
+    u_dfmt = copy(u_dfm)
+    for i in 1:4
+        fill!(view(u_dfmt, 1, :, :, i), i)
+        fill!(view(u_dfmt, 2, :, :, i), 5 - i)
+        ϕ_dfm = GridDeformation(u_dfmt[:, :, :, i], nodes)
+        imgt[tax(i)] = warp(fixed, ϕ_dfm)
     end
-end
 
-jldopen(fn_pp) do f
-    global nfailures
-    mm = read(f["mismatch"])
-    @test all(mm .> 0)
-    warped = read(f["warped"])
-    for i = 1:nimages(img)
-        r0 = ratio(mismatch0(pp(fixed), pp(img[tax(i)])),0)
-        r1 = ratio(mismatch0(pp(fixed), warped[:,:,i]), 0)
-        nfailures += r0 <= r1
-    end
-    warped0 = read(f["warped0"])
-    for i = 1:nimages(img)
-        r0 = ratio(mismatch0(fixed, img[tax(i)]),0)
-        r1 = ratio(mismatch0(fixed, warped0[:,:,i]), 0)
-        nfailures += r0 <= r1
-    end
-end
+    fnt = joinpath(tempdir(), "apertured_translate.jld")
+    maxshift = (3 * shift_amplitude, 3 * shift_amplitude)
+    algorithms = Apertures[Apertures(fixed, nodes, maxshift, 0.001; tid = t) for t in aperturedtids]
+    prepare_mm_package(algorithms)
+    mons = monitor(
+        algorithms,
+        (),
+        Dict(
+            :u => Array{SVector{2, Float64}}(undef, gridsize),
+            :warped => Array{Float64}(undef, size(fixed)),
+            :mismatch => 0.0
+        )
+    )
+    driver(fnt, algorithms, imgt, mons)
 
-@test nfailures <= 2
+    #using JLD, RegisterCore, RegisterMismatch
+
+    jldopen(fnt) do f
+        mm = read(f["mismatch"])
+        u = read(f["u"])
+        @test maximum(abs, u + u_dfmt) < 0.5
+        warped = read(f["warped"])
+        for i in 1:nimages(img)
+            r0 = ratio(mismatch0(fixed, imgt[tax(i)]), 0)
+            r1 = ratio(mismatch0(fixed, warped[:, :, i]), 0)
+            @test r0 > r1
+        end
+    end
+
+    nfailures = 0
+
+    jldopen(fn) do f
+        global nfailures
+        mm = read(f["mismatch"])
+        @test all(mm .> 0)
+        warped = read(f["warped"])
+        for i in 1:nimages(img)
+            r0 = ratio(mismatch0(fixed, img[tax(i)]), 0)
+            r1 = ratio(mismatch0(fixed, warped[:, :, i]), 0)
+            nfailures += r0 <= r1
+        end
+    end
+
+    jldopen(fn_pp) do f
+        global nfailures
+        mm = read(f["mismatch"])
+        @test all(mm .> 0)
+        warped = read(f["warped"])
+        for i in 1:nimages(img)
+            r0 = ratio(mismatch0(pp(fixed), pp(img[tax(i)])), 0)
+            r1 = ratio(mismatch0(pp(fixed), warped[:, :, i]), 0)
+            nfailures += r0 <= r1
+        end
+        warped0 = read(f["warped0"])
+        for i in 1:nimages(img)
+            r0 = ratio(mismatch0(fixed, img[tax(i)]), 0)
+            r1 = ratio(mismatch0(fixed, warped0[:, :, i]), 0)
+            nfailures += r0 <= r1
+        end
+    end
+
+    @test nfailures <= 2
+end

--- a/test/apertured1.jl
+++ b/test/apertured1.jl
@@ -1,87 +1,92 @@
-### Apertured registration
-# Create the data
-img = testimage("cameraman")
-gridsizeg = (4,4) # for generation
-shift_amplitude = 10
-u_dfm = shift_amplitude*randn(2, gridsizeg...)
-nodesg = map(d->range(1, stop=size(img,d), length=gridsizeg[d]), (1,2))
-ϕ_dfm = GridDeformation(u_dfm, nodesg)
-wimg = warp(img, ϕ_dfm)
-o = 3*shift_amplitude
-fixed = img[o+1:size(img,1)-o, o+1:size(img,2)-o]
-moving = wimg[o+1:size(img,1)-o, o+1:size(img,2)-o]
+@testset "Apertured registration (λ sweep)" begin
+    ### Apertured registration
+    # Create the data
+    img = testimage("cameraman")
+    gridsizeg = (4, 4) # for generation
+    shift_amplitude = 10
+    u_dfm = shift_amplitude * randn(2, gridsizeg...)
+    nodesg = map(d -> range(1, stop = size(img, d), length = gridsizeg[d]), (1, 2))
+    ϕ_dfm = GridDeformation(u_dfm, nodesg)
+    wimg = warp(img, ϕ_dfm)
+    o = 3 * shift_amplitude
+    fixed = img[(o + 1):(size(img, 1) - o), (o + 1):(size(img, 2) - o)]
+    moving = wimg[(o + 1):(size(img, 1) - o), (o + 1):(size(img, 2) - o)]
 
-# Set up the range of λ, and prepare for plotting
-λrange = (1e-6,10)
+    # Set up the range of λ, and prepare for plotting
+    λrange = (1.0e-6, 10)
 
-# To make sure it runs, try the example in the docs, even though it's
-# not well-tuned for this case
-pp = img -> imfilter(img, KernelFactors.IIRGaussian((3,3)))
-nodes = (range(1, stop=size(fixed,1), length=5), range(1, stop=size(fixed,2), length=7))
-fixedfilt = pp(fixed)
-maxshift = (30,30)
-alg = Apertures(fixedfilt, nodes, maxshift, λrange, pp)
-prepare_mm_package(alg)
-mon = monitor(alg, (), Dict(:λs=>0, :datapenalty=>0, :λ=>0, :u=>0, :warped0 => Array{Float64}(undef, size(fixed))))
-mon = driver(alg, moving, mon)
-datapenalty = mon[:datapenalty]
-@test !all(mon[:warped0] .== 0)
-# plot(x=λs, y=datapenalty, xintercept=[mon[:λ]], Geom.point, Geom.vline, Guide.xlabel("λ"), Guide.ylabel("Data penalty"), Scale.x_log10)
+    # To make sure it runs, try the example in the docs, even though it's
+    # not well-tuned for this case
+    pp = img -> imfilter(img, KernelFactors.IIRGaussian((3, 3)))
+    nodes = (range(1, stop = size(fixed, 1), length = 5), range(1, stop = size(fixed, 2), length = 7))
+    fixedfilt = pp(fixed)
+    maxshift = (30, 30)
+    alg = Apertures(fixedfilt, nodes, maxshift, λrange, pp)
+    prepare_mm_package(alg)
+    mon = monitor(alg, (), Dict(:λs => 0, :datapenalty => 0, :λ => 0, :u => 0, :warped0 => Array{Float64}(undef, size(fixed))))
+    mon = driver(alg, moving, mon)
+    datapenalty = mon[:datapenalty]
+    @test !all(mon[:warped0] .== 0)
+    # plot(x=λs, y=datapenalty, xintercept=[mon[:λ]], Geom.point, Geom.vline, Guide.xlabel("λ"), Guide.ylabel("Data penalty"), Scale.x_log10)
 
-# Perform the registration
-gridsize = (17,17)  # for correction
-nodes = map(d->range(1, stop=size(fixed,d), length=gridsize[d]), (1,2))
-umax = maximum(abs.(u_dfm))
-maxshift = (ceil(Int, umax)+5, ceil(Int, umax)+5)
-algorithm = RegisterWorkerApertures.Apertures(fixed, nodes, maxshift, λrange)
-prepare_mm_package(algorithm)
-mon = Dict{Symbol,Any}(:u => Array{SVector{2,Float64}}(undef, gridsize),
-                       :mismatch => 0.0,
-                       :λ => 0.0,
-                       :datapenalty => 0,
-                       :sigmoid_quality => 0.0,
-                       :warped => copy(moving))
-mon = driver(algorithm, moving, mon)
+    # Perform the registration
+    gridsize = (17, 17)  # for correction
+    nodes = map(d -> range(1, stop = size(fixed, d), length = gridsize[d]), (1, 2))
+    umax = maximum(abs.(u_dfm))
+    maxshift = (ceil(Int, umax) + 5, ceil(Int, umax) + 5)
+    algorithm = RegisterWorkerApertures.Apertures(fixed, nodes, maxshift, λrange)
+    prepare_mm_package(algorithm)
+    mon = Dict{Symbol, Any}(
+        :u => Array{SVector{2, Float64}}(undef, gridsize),
+        :mismatch => 0.0,
+        :λ => 0.0,
+        :datapenalty => 0,
+        :sigmoid_quality => 0.0,
+        :warped => copy(moving)
+    )
+    mon = driver(algorithm, moving, mon)
 
-# With aperture overlap
-apertureoverlap = 0.3;  #Aperture overlap percentage (between 0 and 1)
-aperture_width = default_aperture_width(fixed, gridsize)
-overlap_t = map(x->round(Int64,x*apertureoverlap), aperture_width)
-algorithm = RegisterWorkerApertures.Apertures(fixed, nodes, maxshift, λrange; overlap=overlap_t)
-prepare_mm_package(algorithm)
-mon_overlap = Dict{Symbol,Any}(:u => Array{SVector{2,Float64}}(undef, gridsize),
-                       :mismatch => 0.0,
-                       :λ => 0.0,
-                       :datapenalty => 0,
-                       :sigmoid_quality => 0.0,
-                       :warped => copy(moving))
-mon_overlap = driver(algorithm, moving, mon_overlap)
+    # With aperture overlap
+    apertureoverlap = 0.3   #Aperture overlap percentage (between 0 and 1)
+    aperture_width = default_aperture_width(fixed, gridsize)
+    overlap_t = map(x -> round(Int64, x * apertureoverlap), aperture_width)
+    algorithm = RegisterWorkerApertures.Apertures(fixed, nodes, maxshift, λrange; overlap = overlap_t)
+    prepare_mm_package(algorithm)
+    mon_overlap = Dict{Symbol, Any}(
+        :u => Array{SVector{2, Float64}}(undef, gridsize),
+        :mismatch => 0.0,
+        :λ => 0.0,
+        :datapenalty => 0,
+        :sigmoid_quality => 0.0,
+        :warped => copy(moving)
+    )
+    mon_overlap = driver(algorithm, moving, mon_overlap)
 
 
+    # Analysis
+    ϕ = GridDeformation(mon[:u], nodes)
+    ϕ_overlap = GridDeformation(mon_overlap[:u], nodes)
 
-# Analysis
-ϕ = GridDeformation(mon[:u], nodes)
-ϕ_overlap = GridDeformation(mon_overlap[:u], nodes)
+    gd0 = warpgrid(ϕ_dfm, showidentity = true)
+    ϕi = interpolate(ϕ_dfm)
 
-gd0 = warpgrid(ϕ_dfm, showidentity=true)
-ϕi = interpolate(ϕ_dfm)
+    gd1 = warpgrid(ϕi(interpolate(ϕ)), showidentity = true)
+    gd1_overlap = warpgrid(ϕi(interpolate(ϕ_overlap)), showidentity = true)
 
-gd1 = warpgrid(ϕi(interpolate(ϕ)), showidentity=true)
-gd1_overlap = warpgrid(ϕi(interpolate(ϕ_overlap)), showidentity=true)
+    r0 = ratio(mismatch0(fixed, moving), 0)
+    r1 = ratio(mismatch0(fixed, mon[:warped]), 0)
+    r1_overlap = ratio(mismatch0(fixed, mon_overlap[:warped]), 0)
+    @test r1 < r0
+    @test r1_overlap < r0
 
-r0 = ratio(mismatch0(fixed, moving), 0)
-r1 = ratio(mismatch0(fixed, mon[:warped]), 0)
-r1_overlap = ratio(mismatch0(fixed, mon_overlap[:warped]), 0)
-@test r1 < r0
-@test r1_overlap < r0
+    # Consider:
+    # using RegisterGUI
+    # ImagePlayer.view(gd0)
+    # ImagePlayer.view(gd1)
+    # showoverlay(fixed, moving)
+    # showoverlay(fixed, mon[:warped])
+    #
+    # plot(x=λs, y=mon[:datapenalty], xintercept=[mon[:λ]], Geom.point, Geom.vline, Guide.xlabel("λ"), Guide.ylabel("Data penalty"), Scale.x_log10)
 
-# Consider:
-# using RegisterGUI
-# ImagePlayer.view(gd0)
-# ImagePlayer.view(gd1)
-# showoverlay(fixed, moving)
-# showoverlay(fixed, mon[:warped])
-#
-# plot(x=λs, y=mon[:datapenalty], xintercept=[mon[:λ]], Geom.point, Geom.vline, Guide.xlabel("λ"), Guide.ylabel("Data penalty"), Scale.x_log10)
-
-nothing
+    nothing
+end

--- a/test/apertured_cuda.jl
+++ b/test/apertured_cuda.jl
@@ -1,85 +1,91 @@
-### Apertured registration
-# Create the data
-img = testimage("cameraman")
-gridsizeg = (4,4) # for generation
-shift_amplitude = 10
-u_dfm = shift_amplitude*randn(2, gridsizeg...)
-nodesg = map(d->range(1, stop=size(img,d), length=gridsizeg[d]), (1,2))
-ϕ_dfm = GridDeformation(u_dfm, nodesg)
-wimg = warp(img, ϕ_dfm)
-o = 3*shift_amplitude
-fixed = img[o+1:size(img,1)-o, o+1:size(img,2)-o]
-moving = wimg[o+1:size(img,1)-o, o+1:size(img,2)-o]
+@testset "Apertured registration (CUDA)" begin
+    ### Apertured registration
+    # Create the data
+    img = testimage("cameraman")
+    gridsizeg = (4, 4) # for generation
+    shift_amplitude = 10
+    u_dfm = shift_amplitude * randn(2, gridsizeg...)
+    nodesg = map(d -> range(1, stop = size(img, d), length = gridsizeg[d]), (1, 2))
+    ϕ_dfm = GridDeformation(u_dfm, nodesg)
+    wimg = warp(img, ϕ_dfm)
+    o = 3 * shift_amplitude
+    fixed = img[(o + 1):(size(img, 1) - o), (o + 1):(size(img, 2) - o)]
+    moving = wimg[(o + 1):(size(img, 1) - o), (o + 1):(size(img, 2) - o)]
 
-# Set up the range of λ, and prepare for plotting
-λrange = (1e-6,10)
+    # Set up the range of λ, and prepare for plotting
+    λrange = (1.0e-6, 10)
 
-# To make sure it runs, try the example in the docs, even though it's
-# not well-tuned for this case
-pp = img -> imfilter(img, KernelFactors.IIRGaussian((3,3)))
-nodes = (range(1, stop=size(fixed,1), length=5), range(1, stop=size(fixed,2), length=7))
-fixedfilt = pp(fixed)
-maxshift = (30,30)
-alg = Apertures(fixedfilt, nodes, maxshift, λrange, pp, dev=0)
-prepare_mm_package(alg)
-mon = monitor(alg, (), Dict(:λs=>0, :datapenalty=>0, :λ=>0, :u=>0, :warped0 => Array{Float64}(undef, size(fixed))))
-mon = driver(alg, moving, mon)
-datapenalty = mon[:datapenalty]
-@test !all(mon[:warped0] .== 0)
-# plot(x=λs, y=datapenalty, xintercept=[mon[:λ]], Geom.point, Geom.vline, Guide.xlabel("λ"), Guide.ylabel("Data penalty"), Scale.x_log10)
+    # To make sure it runs, try the example in the docs, even though it's
+    # not well-tuned for this case
+    pp = img -> imfilter(img, KernelFactors.IIRGaussian((3, 3)))
+    nodes = (range(1, stop = size(fixed, 1), length = 5), range(1, stop = size(fixed, 2), length = 7))
+    fixedfilt = pp(fixed)
+    maxshift = (30, 30)
+    alg = Apertures(fixedfilt, nodes, maxshift, λrange, pp, dev = 0)
+    prepare_mm_package(alg)
+    mon = monitor(alg, (), Dict(:λs => 0, :datapenalty => 0, :λ => 0, :u => 0, :warped0 => Array{Float64}(undef, size(fixed))))
+    mon = driver(alg, moving, mon)
+    datapenalty = mon[:datapenalty]
+    @test !all(mon[:warped0] .== 0)
+    # plot(x=λs, y=datapenalty, xintercept=[mon[:λ]], Geom.point, Geom.vline, Guide.xlabel("λ"), Guide.ylabel("Data penalty"), Scale.x_log10)
 
-# Perform the registration
-gridsize = (17,17)  # for correction
-nodes = map(d->range(1, stop=size(fixed,d), length=gridsize[d]), (1,2))
-umax = maximum(abs.(u_dfm))
-maxshift = (ceil(Int, umax)+5, ceil(Int, umax)+5)
-algorithm = RegisterWorkerApertures.Apertures(fixed, nodes, maxshift, λrange, dev=0)
-prepare_mm_package(algorithm)
-mon = Dict{Symbol,Any}(:u => Array{SVector{2,Float64}}(undef, gridsize),
-                       :mismatch => 0.0,
-                       :λ => 0.0,
-                       :datapenalty => 0,
-                       :sigmoid_quality => 0.0,
-                       :warped => copy(moving))
-mon = driver(algorithm, moving, mon)
+    # Perform the registration
+    gridsize = (17, 17)  # for correction
+    nodes = map(d -> range(1, stop = size(fixed, d), length = gridsize[d]), (1, 2))
+    umax = maximum(abs.(u_dfm))
+    maxshift = (ceil(Int, umax) + 5, ceil(Int, umax) + 5)
+    algorithm = RegisterWorkerApertures.Apertures(fixed, nodes, maxshift, λrange, dev = 0)
+    prepare_mm_package(algorithm)
+    mon = Dict{Symbol, Any}(
+        :u => Array{SVector{2, Float64}}(undef, gridsize),
+        :mismatch => 0.0,
+        :λ => 0.0,
+        :datapenalty => 0,
+        :sigmoid_quality => 0.0,
+        :warped => copy(moving)
+    )
+    mon = driver(algorithm, moving, mon)
 
-# With aperture overlap
-apertureoverlap = 0.3;  #Aperture overlap percentage (between 0 and 1)
-aperture_width = default_aperture_width(fixed, gridsize)
-overlap_t = map(x->round(Int64,x*apertureoverlap), aperture_width)
-algorithm = RegisterWorkerApertures.Apertures(fixed, nodes, maxshift, λrange; overlap=overlap_t, dev=0)
-prepare_mm_package(algorithm)
-mon_overlap = Dict{Symbol,Any}(:u => Array{SVector{2,Float64}}(undef, gridsize),
-                       :mismatch => 0.0,
-                       :λ => 0.0,
-                       :datapenalty => 0,
-                       :sigmoid_quality => 0.0,
-                       :warped => copy(moving))
-mon_overlap = driver(algorithm, moving, mon_overlap)
+    # With aperture overlap
+    apertureoverlap = 0.3   #Aperture overlap percentage (between 0 and 1)
+    aperture_width = default_aperture_width(fixed, gridsize)
+    overlap_t = map(x -> round(Int64, x * apertureoverlap), aperture_width)
+    algorithm = RegisterWorkerApertures.Apertures(fixed, nodes, maxshift, λrange; overlap = overlap_t, dev = 0)
+    prepare_mm_package(algorithm)
+    mon_overlap = Dict{Symbol, Any}(
+        :u => Array{SVector{2, Float64}}(undef, gridsize),
+        :mismatch => 0.0,
+        :λ => 0.0,
+        :datapenalty => 0,
+        :sigmoid_quality => 0.0,
+        :warped => copy(moving)
+    )
+    mon_overlap = driver(algorithm, moving, mon_overlap)
 
-# Analysis
-ϕ = GridDeformation(mon[:u], nodes)
-ϕ_overlap = GridDeformation(mon_overlap[:u], nodes)
+    # Analysis
+    ϕ = GridDeformation(mon[:u], nodes)
+    ϕ_overlap = GridDeformation(mon_overlap[:u], nodes)
 
-gd0 = warpgrid(ϕ_dfm, showidentity=true)
-ϕi = interpolate(ϕ_dfm)
+    gd0 = warpgrid(ϕ_dfm, showidentity = true)
+    ϕi = interpolate(ϕ_dfm)
 
-gd1 = warpgrid(ϕi(interpolate(ϕ)), showidentity=true)
-gd1_overlap = warpgrid(ϕi(interpolate(ϕ_overlap)), showidentity=true)
+    gd1 = warpgrid(ϕi(interpolate(ϕ)), showidentity = true)
+    gd1_overlap = warpgrid(ϕi(interpolate(ϕ_overlap)), showidentity = true)
 
-r0 = ratio(mismatch0(fixed, moving), 0)
-r1 = ratio(mismatch0(fixed, mon[:warped]), 0)
-r1_overlap = ratio(mismatch0(fixed, mon_overlap[:warped]), 0)
-@test r1 < r0
-@test r1_overlap < r0
+    r0 = ratio(mismatch0(fixed, moving), 0)
+    r1 = ratio(mismatch0(fixed, mon[:warped]), 0)
+    r1_overlap = ratio(mismatch0(fixed, mon_overlap[:warped]), 0)
+    @test r1 < r0
+    @test r1_overlap < r0
 
-# Consider:
-# using RegisterGUI
-# ImagePlayer.view(gd0)
-# ImagePlayer.view(gd1)
-# showoverlay(fixed, moving)
-# showoverlay(fixed, mon[:warped])
-#
-# plot(x=λs, y=mon[:datapenalty], xintercept=[mon[:λ]], Geom.point, Geom.vline, Guide.xlabel("λ"), Guide.ylabel("Data penalty"), Scale.x_log10)
+    # Consider:
+    # using RegisterGUI
+    # ImagePlayer.view(gd0)
+    # ImagePlayer.view(gd1)
+    # showoverlay(fixed, moving)
+    # showoverlay(fixed, mon[:warped])
+    #
+    # plot(x=λs, y=mon[:datapenalty], xintercept=[mon[:λ]], Geom.point, Geom.vline, Guide.xlabel("λ"), Guide.ylabel("Data penalty"), Scale.x_log10)
 
-nothing
+    nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ using RegisterCore, RegisterDeformation, RegisterMismatchCommon
 using RegisterWorkerApertures, RegisterDriver
 using AxisArrays: AxisArray
 
-if !(haskey(ENV,"CI")&&(ENV["CI"]=="true"))
+if !(haskey(ENV, "CI")&&(ENV["CI"] == "true"))
     include("apertured_cuda.jl")
 else
     include("apertured.jl")


### PR DESCRIPTION
## Summary
- Apply `runic` formatting to `src/` and `test/`
- Wrap all test file contents in named `@testset` blocks

This commit contains only formatting and test structure changes — no functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)